### PR TITLE
Copy with MIME type text/uri-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ require("xpm").setup({
   -- Or
 
   require("wl-clipboard").setup{
-    copy_command = "wl-copy",
+    copy_command = "wl-copy -t text/uri-list",
     paste_command = "wl-paste",
     keep_selection = false,
   }

--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@ local function setup(args)
   local xplr = xplr
 
   args = args or {}
-  args.copy_command = args.copy_command or "wl-copy"
+  args.copy_command = args.copy_command or "wl-copy -t text/uri-list"
   args.paste_command = args.paste_command or "wl-paste"
   args.keep_selection = args.keep_selection or false
 


### PR DESCRIPTION
This backwards-compatible change allows for a huge benefit: other apps (file managers, chat apps, etc.) might understand that the contents of the clipboard is not just any text, but (a list of) files. This enables for scenarios such as:

- Find a file/picture that you want to send to a friend in a chat app, copy using xplr, paste in chat app - and pictures would be sent, instead of your file names.
- Copy files in xplr and paste in another file browser.

Not apps support this, obviously, so for them the behavior would be exactly as today - they'd just read the clipboard as if it was plain text.

There's no change for xplr pasting capabilities as it doesn't care of the MIME type, but in principle it _could_ check whether clipboard type is text/uri-list and early abort if it's not (I believe other file managers like Nemo do exactly this, although Nemo devised their own custom MIME type in addition to text/uri-list...)